### PR TITLE
feat: sync db with chain validators state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,6 +2274,7 @@ name = "kiln-postgres"
 version = "0.1.0"
 dependencies = [
  "diesel",
+ "eth2",
  "primitive-types 0.10.1",
  "serde",
 ]

--- a/eth-parser/src/client_consensus/mod.rs
+++ b/eth-parser/src/client_consensus/mod.rs
@@ -31,14 +31,13 @@ pub async fn get_head_height(client: &BeaconNodeHttpClient) -> Result<u64, Error
 	Ok(ret.data.head_slot.as_u64())
 }
 
-/// Return the list of validators at a given slot
+/// Return the list of validators at head
 ///
 /// https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidators
-pub async fn get_validators_at_slot(
+pub async fn get_validators_at_head(
 	client: &BeaconNodeHttpClient,
-	slot_id: u64,
 ) -> Result<Option<Vec<ValidatorData>>, Error> {
-	let state_id = StateId::Slot(Slot::new(slot_id));
+	let state_id = StateId::Head;
 	let opt_r = client.get_beacon_states_validators(state_id, None, None).await?;
 
 	Ok(opt_r.map(|r| r.data))
@@ -56,7 +55,6 @@ pub async fn get_config_spec(client: &BeaconNodeHttpClient) -> Result<ConfigAndP
 /// Return the block at `slot_height`
 ///
 /// https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2
-#[allow(dead_code)]
 pub async fn get_block(
 	client: &BeaconNodeHttpClient,
 	slot_height: u64,

--- a/eth-parser/src/sync/execution_layer.rs
+++ b/eth-parser/src/sync/execution_layer.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+	fmt::Display,
+	sync::{Arc, Mutex},
+};
 
 use async_trait::async_trait;
 use diesel::PgConnection;
@@ -17,14 +20,16 @@ impl ExecutionSyncer {
 	}
 }
 
+impl Display for ExecutionSyncer {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "execution syncer")
+	}
+}
+
 #[async_trait]
 impl DbSyncer for ExecutionSyncer {
 	type DbConnection = PgConnection;
 	type NodeClient = Web3<Http>;
-
-	fn name(&self) -> String {
-		"execution Layer".to_owned()
-	}
 
 	fn db_conn(&self) -> Arc<Mutex<Self::DbConnection>> {
 		self.0.clone()

--- a/eth-parser/src/sync/mod.rs
+++ b/eth-parser/src/sync/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod consensus_layer;
 pub(crate) mod execution_layer;
 pub(crate) mod syncer;
+pub(crate) mod validators;
 
 pub(crate) use consensus_layer::*;
 pub(crate) use execution_layer::*;

--- a/eth-parser/src/sync/validators.rs
+++ b/eth-parser/src/sync/validators.rs
@@ -1,0 +1,46 @@
+use std::{
+	sync::{Arc, Mutex},
+	time::Duration,
+};
+
+use diesel::PgConnection;
+use eth2::BeaconNodeHttpClient;
+use kiln_postgres::NewValidators;
+use log::{info, warn};
+use tokio::time;
+
+use crate::{client_consensus, error::Error};
+
+use super::SyncError;
+
+/// Keep the validator table in sync with the last state of the chain
+///
+/// Never return due to infinite loop
+pub async fn sync_last_validator_state(
+	conn: Arc<Mutex<PgConnection>>,
+	client: BeaconNodeHttpClient,
+	interval_duration: Duration,
+) {
+	let mut sync_interval = time::interval(interval_duration);
+	loop {
+		sync_interval.tick().await;
+		match update_validators(conn.clone(), &client).await {
+			Ok(_) => info!("Validators updated"),
+			Err(err) => warn!("Failed to update validators: {err}"),
+		}
+	}
+}
+
+async fn update_validators(
+	conn: Arc<Mutex<PgConnection>>,
+	client: &BeaconNodeHttpClient,
+) -> Result<(), Error> {
+	let validators = client_consensus::get_validators_at_head(client)
+		.await?
+		.ok_or(SyncError::NoValidators)?;
+
+	let new_validators = NewValidators::from_iter(validators.into_iter().map(|v| v.into()));
+	new_validators.batch_upsert(&conn.lock().unwrap())?;
+
+	Ok(())
+}

--- a/kiln-postgres/Cargo.toml
+++ b/kiln-postgres/Cargo.toml
@@ -6,5 +6,6 @@ version = "0.1.0"
 
 [dependencies]
 diesel          = { version = "1.4.8", features = ["postgres"] }
+eth2            = { git = "http://github.com/sigp/lighthouse", branch = "unstable" }
 primitive-types = { version = "0.10.1", features = ["serde"] }
 serde           = { version = "1.0.136", features = ["derive"] }

--- a/kiln-postgres/migrations/2022-03-17-165525_create_table_slots/up.sql
+++ b/kiln-postgres/migrations/2022-03-17-165525_create_table_slots/up.sql
@@ -2,7 +2,6 @@
 
 CREATE TABLE slots (
     height BIGINT PRIMARY KEY,
-    validators_count BIGINT NOT NULL,
     block_hash BYTEA,
     block_number BIGINT
 );

--- a/kiln-postgres/migrations/2022-03-30-093023_create_table_validators/down.sql
+++ b/kiln-postgres/migrations/2022-03-30-093023_create_table_validators/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE validators;

--- a/kiln-postgres/migrations/2022-03-30-093023_create_table_validators/up.sql
+++ b/kiln-postgres/migrations/2022-03-30-093023_create_table_validators/up.sql
@@ -1,0 +1,15 @@
+-- Your SQL goes here
+
+CREATE TABLE validators (
+    "index" BIGINT PRIMARY KEY,
+    balance BIGINT NOT NULL,
+    "status" VARCHAR NOT NULL,
+    pubkey VARCHAR NOT NULL,
+    withdrawal_credentials BYTEA NOT NULL,
+    effective_balance BIGINT NOT NULL,
+    slashed BOOLEAN NOT NULL,
+    activation_eligibility_epoch BIGINT NOT NULL,
+    activation_epoch BIGINT NOT NULL,
+    exit_epoch BIGINT NOT NULL,
+    withdrawable_epoch BIGINT NOT NULL
+);

--- a/kiln-postgres/src/models/mod.rs
+++ b/kiln-postgres/src/models/mod.rs
@@ -2,8 +2,10 @@ mod execution_blocks;
 mod slots;
 mod transactions;
 mod types;
+mod validators;
 
 pub use execution_blocks::*;
 pub use slots::*;
 pub use transactions::*;
 pub(self) use types::*;
+pub use validators::*;

--- a/kiln-postgres/src/models/slots/insertable.rs
+++ b/kiln-postgres/src/models/slots/insertable.rs
@@ -10,22 +10,15 @@ pub struct NewSlot {
 	// postgresql doesn't support unsigned types
 	// all u64 are stored as i64 and converted back when used
 	height: i64,
-	validators_count: i64,
 	block_hash: Option<Hash256>,
 	block_number: Option<i64>,
 }
 
 impl NewSlot {
 	/// Return a new insertable slot
-	pub fn new(
-		height: u64,
-		validators_count: usize,
-		block_hash: Option<H256>,
-		block_number: Option<u64>,
-	) -> NewSlot {
+	pub fn new(height: u64, block_hash: Option<H256>, block_number: Option<u64>) -> NewSlot {
 		NewSlot {
 			height: height as i64,
-			validators_count: validators_count as i64,
 			block_hash: block_hash.map(|h| h.into()),
 			block_number: block_number.map(|n| n as i64),
 		}

--- a/kiln-postgres/src/models/slots/queryable.rs
+++ b/kiln-postgres/src/models/slots/queryable.rs
@@ -15,7 +15,6 @@ struct DbSlot {
 	// postgresql doesn't support unsigned types
 	// all u64 are stored as i64 and converted back when used
 	height: i64,
-	validators_count: i64,
 	block_hash: Option<Hash256>,
 	block_number: Option<i64>,
 }
@@ -23,7 +22,6 @@ struct DbSlot {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Slot {
 	height: u64,
-	validators_count: u64,
 	block_hash: Option<H256>,
 	block_number: Option<u64>,
 }
@@ -32,7 +30,6 @@ impl From<DbSlot> for Slot {
 	fn from(db_slot: DbSlot) -> Self {
 		Slot {
 			height: db_slot.height as u64,
-			validators_count: db_slot.validators_count as u64,
 			block_hash: db_slot.block_hash.map(|h| h.into()),
 			block_number: db_slot.block_number.map(|n| n as u64),
 		}
@@ -43,11 +40,6 @@ impl Slot {
 	/// Return the height of the slot
 	pub fn height(&self) -> u64 {
 		self.height
-	}
-
-	/// Return the validator count of the slot
-	pub fn validators_count(&self) -> u64 {
-		self.validators_count
 	}
 
 	/// Return the hash of the slot's execution block

--- a/kiln-postgres/src/models/validators/insertable.rs
+++ b/kiln-postgres/src/models/validators/insertable.rs
@@ -1,0 +1,80 @@
+use diesel::{
+	pg::upsert::excluded, ExpressionMethods, Insertable, PgConnection, QueryResult, RunQueryDsl,
+};
+use eth2::types::ValidatorData;
+
+use crate::{models::Hash256, schema::validators};
+
+#[derive(Insertable)]
+#[table_name = "validators"]
+pub struct NewValidator {
+	index: i64,
+	balance: i64,
+	status: String,
+	pubkey: String,
+	withdrawal_credentials: Hash256,
+	effective_balance: i64,
+	slashed: bool,
+	activation_eligibility_epoch: i64,
+	activation_epoch: i64,
+	exit_epoch: i64,
+	withdrawable_epoch: i64,
+}
+
+impl From<ValidatorData> for NewValidator {
+	fn from(data: ValidatorData) -> Self {
+		NewValidator {
+			index: data.index as i64,
+			balance: data.balance as i64,
+			status: data.status.to_string(),
+			pubkey: data.validator.pubkey.to_string(),
+			withdrawal_credentials: data.validator.withdrawal_credentials.into(),
+			effective_balance: data.validator.effective_balance as i64,
+			slashed: data.validator.slashed,
+			activation_eligibility_epoch: data.validator.activation_eligibility_epoch.as_u64()
+				as i64,
+			activation_epoch: data.validator.activation_epoch.as_u64() as i64,
+			exit_epoch: data.validator.exit_epoch.as_u64() as i64,
+			withdrawable_epoch: data.validator.withdrawable_epoch.as_u64() as i64,
+		}
+	}
+}
+
+/// An wrapper around an array fo validators
+pub struct NewValidators(Vec<NewValidator>);
+
+impl NewValidators {
+	/// Upsert an array of validators in db
+	///
+	/// # Updated fields
+	/// `balance`, `status`, `withdrawal_credentials`, `effective_balance`, `slashed`
+	pub fn batch_upsert(&self, conn: &PgConnection) -> QueryResult<()> {
+		for chunk in self.0.chunks(1000) {
+			diesel::insert_into(validators::table)
+				.values(chunk)
+				.on_conflict(validators::index)
+				.do_update()
+				.set((
+					validators::balance.eq(excluded(validators::balance)),
+					validators::status.eq(excluded(validators::status)),
+					validators::withdrawal_credentials
+						.eq(excluded(validators::withdrawal_credentials)),
+					validators::effective_balance.eq(excluded(validators::effective_balance)),
+					validators::slashed.eq(excluded(validators::slashed)),
+				))
+				.execute(conn)?;
+		}
+
+		Ok(())
+	}
+}
+
+impl FromIterator<NewValidator> for NewValidators {
+	fn from_iter<T: IntoIterator<Item = NewValidator>>(iter: T) -> Self {
+		let mut validators = vec![];
+		for t in iter {
+			validators.push(t);
+		}
+		NewValidators(validators)
+	}
+}

--- a/kiln-postgres/src/models/validators/mod.rs
+++ b/kiln-postgres/src/models/validators/mod.rs
@@ -1,0 +1,5 @@
+mod insertable;
+mod queryable;
+
+pub use insertable::*;
+pub use queryable::*;

--- a/kiln-postgres/src/models/validators/queryable.rs
+++ b/kiln-postgres/src/models/validators/queryable.rs
@@ -1,0 +1,78 @@
+use diesel::{ExpressionMethods, Identifiable, PgConnection, QueryDsl, QueryResult, RunQueryDsl};
+use primitive_types::H256;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+	models::Hash256,
+	schema::{validators, validators::dsl::validators as dsl_validators},
+};
+
+#[derive(Queryable, Identifiable)]
+#[primary_key(index)]
+#[table_name = "validators"]
+struct DbValidator {
+	index: i64,
+	balance: i64,
+	status: String,
+	pubkey: String,
+	withdrawal_credentials: Hash256,
+	effective_balance: i64,
+	slashed: bool,
+	activation_eligibility_epoch: i64,
+	activation_epoch: i64,
+	exit_epoch: i64,
+	withdrawable_epoch: i64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Validator {
+	index: u64,
+	balance: u64,
+	status: String,
+	pubkey: String,
+	withdrawal_credentials: H256,
+	effective_balance: u64,
+	slashed: bool,
+	activation_eligibility_epoch: u64,
+	activation_epoch: u64,
+	exit_epoch: u64,
+	withdrawable_epoch: u64,
+}
+
+impl From<DbValidator> for Validator {
+	fn from(db_validator: DbValidator) -> Self {
+		Validator {
+			index: db_validator.index as u64,
+			balance: db_validator.balance as u64,
+			status: db_validator.status,
+			pubkey: db_validator.pubkey,
+			withdrawal_credentials: db_validator.withdrawal_credentials.into(),
+			effective_balance: db_validator.effective_balance as u64,
+			slashed: db_validator.slashed,
+			activation_eligibility_epoch: db_validator.activation_eligibility_epoch as u64,
+			activation_epoch: db_validator.activation_epoch as u64,
+			exit_epoch: db_validator.exit_epoch as u64,
+			withdrawable_epoch: db_validator.withdrawable_epoch as u64,
+		}
+	}
+}
+
+impl Validator {
+	/// Return a list of all validators `withdrawal_credentials`
+	pub fn list_credentials(conn: &PgConnection) -> QueryResult<Vec<H256>> {
+		let credentials: Vec<Hash256> =
+			dsl_validators.select(validators::withdrawal_credentials).load(conn)?;
+
+		Ok(credentials.into_iter().map(|v| v.into()).collect())
+	}
+
+	/// Return a list of all slashed validators `withdrawal_credentials`
+	pub fn list_slashed_credentials(conn: &PgConnection) -> QueryResult<Vec<H256>> {
+		let slashed: Vec<Hash256> = dsl_validators
+			.filter(validators::slashed.eq(true))
+			.select(validators::withdrawal_credentials)
+			.load(conn)?;
+
+		Ok(slashed.into_iter().map(|v| v.into()).collect())
+	}
+}

--- a/kiln-postgres/src/schema.rs
+++ b/kiln-postgres/src/schema.rs
@@ -12,7 +12,6 @@ table! {
 table! {
 	slots (height) {
 		height -> Int8,
-		validators_count -> Int8,
 		block_hash -> Nullable<Bytea>,
 		block_number -> Nullable<Int8>,
 	}
@@ -28,6 +27,22 @@ table! {
 	}
 }
 
+table! {
+	validators (index) {
+		index -> Int8,
+		balance -> Int8,
+		status -> Varchar,
+		pubkey -> Varchar,
+		withdrawal_credentials -> Bytea,
+		effective_balance -> Int8,
+		slashed -> Bool,
+		activation_eligibility_epoch -> Int8,
+		activation_epoch -> Int8,
+		exit_epoch -> Int8,
+		withdrawable_epoch -> Int8,
+	}
+}
+
 joinable!(transactions -> execution_blocks (block_hash));
 
-allow_tables_to_appear_in_same_query!(execution_blocks, slots, transactions,);
+allow_tables_to_appear_in_same_query!(execution_blocks, slots, transactions, validators,);

--- a/web-api/src/main.rs
+++ b/web-api/src/main.rs
@@ -1,9 +1,10 @@
 mod params;
 
 use dotenv::dotenv;
+use primitive_types::H256;
 use rocket::{get, launch, routes, serde::json::Json};
 
-use kiln_postgres::{ExecBlock, Slot, Transaction};
+use kiln_postgres::{ExecBlock, Slot, Transaction, Validator};
 use rocket_sync_db_pools::{database, diesel};
 
 use params::Hash256;
@@ -11,19 +12,38 @@ use params::Hash256;
 #[database("kiln_pg")]
 struct PgConn(diesel::PgConnection);
 
+/// Return a consensus layer slot by `height`
 #[get("/slot/<height>")]
 async fn slot(conn: PgConn, height: u64) -> Option<Json<Slot>> {
 	conn.run(move |c| Slot::get(c, height)).await.map(Json).ok()
 }
 
+/// Return an execution layer block by `height`
 #[get("/block/<number>")]
 async fn block(conn: PgConn, number: u64) -> Option<Json<ExecBlock>> {
 	conn.run(move |c| ExecBlock::get(c, number)).await.map(Json).ok()
 }
 
+/// Return an execution block transaction by `hash`
 #[get("/transaction/<hash>")]
 async fn transaction(conn: PgConn, hash: Hash256) -> Option<Json<Transaction>> {
 	conn.run(move |c| Transaction::get(c, hash.into())).await.map(Json).ok()
+}
+
+/// Return the validators IDs
+///
+/// The returned values are hashs of the `withdrawal_credentials` associated to a validator
+#[get("/validators")]
+async fn validators(conn: PgConn) -> Option<Json<Vec<H256>>> {
+	conn.run(move |c| Validator::list_credentials(c)).await.map(Json).ok()
+}
+
+/// Return the slashed validators IDs
+///
+/// The returned values are hashs of the `withdrawal_credentials` associated to a validator
+#[get("/validators/slashed")]
+async fn validators_slashed(conn: PgConn) -> Option<Json<Vec<H256>>> {
+	conn.run(move |c| Validator::list_slashed_credentials(c)).await.map(Json).ok()
 }
 
 #[launch]
@@ -31,7 +51,8 @@ fn rocket() -> _ {
 	dotenv().ok();
 	env_logger::init();
 
-	rocket::build()
-		.attach(PgConn::fairing())
-		.mount("/", routes![slot, block, transaction])
+	rocket::build().attach(PgConn::fairing()).mount(
+		"/",
+		routes![slot, block, transaction, validators, validators_slashed],
+	)
 }


### PR DESCRIPTION
remove the storing of number of validators at each block

add validators table, syncing loop and api route

BREAKING CHANGE: remove field validators_count from create_table_slots migration